### PR TITLE
fix typo: longitude value being set to latitude value

### DIFF
--- a/libs/yowsup/yowsup/layers/axolotl/layer_receive.py
+++ b/libs/yowsup/yowsup/layers/axolotl/layer_receive.py
@@ -360,7 +360,7 @@ class AxolotlReceivelayer(AxolotlBaseLayer):
             messageNode["type"] = "media"
             mediaNode = ProtocolTreeNode("media", {
                 "latitude": locationMessage.degrees_latitude,
-                "longitude": locationMessage.degrees_latitude,
+                "longitude": locationMessage.degrees_longitude,
                 "name": "%s %s" % (locationMessage.name, locationMessage.address),
                 "url": locationMessage.url,
                 "encoding": "raw",


### PR DESCRIPTION
simple fix so that longitude values are reported correctly